### PR TITLE
Fix column header formatting in A1 notation

### DIFF
--- a/hyou/util.py
+++ b/hyou/util.py
@@ -14,9 +14,12 @@
 
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
+
+import string
 from builtins import (  # noqa: F401
     ascii, bytes, chr, dict, filter, hex, input, int, list, map, next,
     object, oct, open, pow, range, round, str, super, zip)
+
 
 import json
 
@@ -36,15 +39,11 @@ def to_native_str(s):
 
 
 def format_column_address(index_column):
-    k = index_column
-    p = 1
-    while k >= 26 ** p:
-        k -= 26 ** p
-        p += 1
-    s = ''
-    for i in range(p):
-        s = chr(ord('A') + k % 26) + s
-    return s
+    letters = []
+    while index_column >= 0:
+        letters.append(string.ascii_uppercase[index_column % 26])
+        index_column = index_column // 26 - 1
+    return ''.join(reversed(letters))
 
 
 def format_range_a1_notation(

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -42,6 +42,9 @@ class MiscUtilsTest(unittest.TestCase):
         assert hyou.util.format_column_address(1) == 'B'
         assert hyou.util.format_column_address(25) == 'Z'
         assert hyou.util.format_column_address(26) == 'AA'
+        assert hyou.util.format_column_address(27) == 'AB'
+        assert hyou.util.format_column_address(26 + 26) == 'BA'
+        assert hyou.util.format_column_address(26 + 26 + 1) == 'BB'
         assert hyou.util.format_column_address(26 + 26 * 26 - 1) == 'ZZ'
         assert hyou.util.format_column_address(26 + 26 * 26) == 'AAA'
 


### PR DESCRIPTION
Using the `util. format_column_address()` from the original stable version.