### PR TITLE
Retry all requests that fail with a 50x error

### DIFF
--- a/hyou/__init__.py
+++ b/hyou/__init__.py
@@ -23,6 +23,7 @@ from .worksheet import Worksheet
 
 login = Collection.login
 
+
 __version__ = '3.0b2'
 
 __all__ = [

--- a/hyou/api.py
+++ b/hyou/api.py
@@ -55,7 +55,7 @@ def _do_exp_backoff(func, max_num_retries):
             return func()
         except googleapiclient.errors.HttpError as err:
             if err.resp.status >= 500 and num_retry < max_num_retries:
-                upper_bound = 2 ^ num_retry
+                upper_bound = 2 ** num_retry
                 num_retry += 1
             else:
                 raise

--- a/hyou/collection.py
+++ b/hyou/collection.py
@@ -40,6 +40,7 @@ class Collection(util.LazyOrderedDictionary):
         http = credentials.authorize(httplib2.Http())
         return cls(api.API(http, discovery=discovery))
 
+    @api.retry_on_server_error
     def create_spreadsheet(self, title, rows=1000, cols=26):
         body = {
             'title': title,
@@ -52,6 +53,7 @@ class Collection(util.LazyOrderedDictionary):
         spreadsheet[0].set_size(rows, cols)
         return spreadsheet
 
+    @api.retry_on_server_error
     def _spreadsheet_enumerator(self):
         response = self._api.drive.files().list(
             maxResults=1000,
@@ -62,6 +64,7 @@ class Collection(util.LazyOrderedDictionary):
             key = item['id']
             yield (key, spreadsheet.Spreadsheet(self._api, key, None))
 
+    @api.retry_on_server_error
     def _spreadsheet_constructor(self, key):
         entry = self._api.sheets.spreadsheets().get(
             spreadsheetId=key, includeGridData=False).execute()

--- a/hyou/spreadsheet.py
+++ b/hyou/spreadsheet.py
@@ -17,6 +17,7 @@ from __future__ import (
 
 import datetime
 
+from . import api
 from . import util
 from . import worksheet
 
@@ -33,6 +34,7 @@ class Spreadsheet(util.LazyOrderedDictionary):
     def __repr__(self):
         return str('Spreadsheet(key=%r)') % (self.key,)
 
+    @api.retry_on_server_error
     def refresh(self, entry=None):
         if entry is not None:
             self._entry = entry
@@ -90,6 +92,7 @@ class Spreadsheet(util.LazyOrderedDictionary):
         self.refresh(new_entry)
 
     @property
+    @api.retry_on_server_error
     def updated(self):
         if not self._updated:
             response = self._api.drive.files().get(fileId=self.key).execute()
@@ -107,6 +110,7 @@ class Spreadsheet(util.LazyOrderedDictionary):
             aworksheet = worksheet.Worksheet(self, self._api, sheet_entry)
             yield (aworksheet.title, aworksheet)
 
+    @api.retry_on_server_error
     def _make_single_batch_request(self, method, params):
         request = {
             'requests': [{method: params}],

--- a/hyou/util.py
+++ b/hyou/util.py
@@ -16,14 +16,13 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import json
+import string
 
 import oauth2client.client
 import oauth2client.service_account
 import six
-import string
 
 from . import py3
-
 
 SCOPES = (
     'https://spreadsheets.google.com/feeds',

--- a/hyou/view.py
+++ b/hyou/view.py
@@ -17,6 +17,7 @@ from __future__ import (
 
 import six
 
+from . import api
 from . import py3
 from . import util
 
@@ -42,6 +43,7 @@ class View(util.CustomMutableFixedList):
         self._cells_fetched = False
         del self._queued_updates[:]
 
+    @api.retry_on_server_error
     def _ensure_cells_fetched(self):
         if self._cells_fetched:
             return
@@ -62,6 +64,7 @@ class View(util.CustomMutableFixedList):
                 self._input_value_map.setdefault((index_row, index_col), value)
         self._cells_fetched = True
 
+    @api.retry_on_server_error
     def commit(self):
         if not self._queued_updates:
             return

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -20,10 +20,9 @@ import logging
 import unittest
 
 import googleapiclient.errors
+import hyou.api
 import mock
 import nose.tools
-
-import hyou.api
 
 import http_mocks
 

--- a/test/http_mocks.py
+++ b/test/http_mocks.py
@@ -16,17 +16,16 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import hashlib
-import httplib2
 import json
 import logging
 import os
 import random
 
 import googleapiclient.errors
-from six.moves.urllib import parse
-
-from hyou import py3
+import httplib2
+import hyou.py3
 import hyou.util
+from six.moves.urllib import parse
 
 
 RECORDS_DIR = os.path.join(os.path.dirname(__file__), 'records')
@@ -43,7 +42,7 @@ def _canonicalize_uri(uri):
 
 def _canonicalize_json(body_json):
     # body_json can be bytes or str.
-    if isinstance(body_json, py3.str):
+    if isinstance(body_json, hyou.py3.str):
         json_str = body_json
     else:
         json_str = body_json.decode('utf-8')
@@ -64,7 +63,7 @@ def _load_records():
     records = {}
     for filename in sorted(os.listdir(RECORDS_DIR)):
         record_path = os.path.join(RECORDS_DIR, filename)
-        with py3.open(record_path, 'r', encoding='utf-8') as f:
+        with hyou.py3.open(record_path, 'r', encoding='utf-8') as f:
             record = json.load(f)
             record['_path'] = record_path
             body_bytes = (
@@ -92,7 +91,7 @@ class ReplayHttp(object):
         else:
             json_path = os.path.join(
                 os.path.dirname(__file__), 'creds', json_name)
-            with py3.open(json_path, 'r') as f:
+            with hyou.py3.open(json_path, 'r') as f:
                 credentials = hyou.util.parse_credentials(f.read())
             self._real_http = credentials.authorize(httplib2.Http())
         self._records = _load_records()

--- a/test/spreadsheet_test.py
+++ b/test/spreadsheet_test.py
@@ -19,11 +19,10 @@ import datetime
 import unittest
 
 import googleapiclient.errors
-import mock
-import nose.tools
-
 import hyou.api
 import hyou.collection
+import mock
+import nose.tools
 
 import http_mocks
 

--- a/test/spreadsheet_test.py
+++ b/test/spreadsheet_test.py
@@ -18,19 +18,45 @@ from __future__ import (
 import datetime
 import unittest
 
+import googleapiclient.errors
+import mock
+import nose.tools
+
 import hyou.api
 import hyou.collection
 
 import http_mocks
 
 
-class SpreadsheetReadOnlyTest(unittest.TestCase):
+CREDENTIALS_FILE = 'unittest-sheets.json'
+
+
+class SpreadsheetTestBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls.api = hyou.api.API(
-            http_mocks.ReplayHttp('unittest-sheets.json'),
+            http_mocks.ReplayHttp(CREDENTIALS_FILE),
             discovery=False)
+
+
+class RetryTestBase(object):
+
+    sleep_patcher = mock.patch('time.sleep')  # Makes the tests run faster
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sleep_patcher.start()
+        cls.error_http = http_mocks.ErrorHttp(
+            CREDENTIALS_FILE, hyou.api.NUM_RETRIES)
+        cls.api = hyou.api.API(cls.error_http, discovery=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sleep_patcher.stop()
+
+
+class SpreadsheetReadOnlyTest(SpreadsheetTestBase):
 
     def setUp(self):
         self.collection = hyou.collection.Collection(self.api)
@@ -94,13 +120,22 @@ class SpreadsheetReadOnlyTest(unittest.TestCase):
             isinstance(self.spreadsheet.updated, datetime.datetime))
 
 
-class SpreadsheetReadWriteTest(unittest.TestCase):
+class RetrySpreadsheetReadOnlyTest(RetryTestBase, SpreadsheetReadOnlyTest):
+    """Same tests as above, but involving retries on server errors."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.api = hyou.api.API(
-            http_mocks.ReplayHttp('unittest-sheets.json'),
-            discovery=False)
+    def setUp(self):
+        self.error_http.request_num = 0
+        super(RetrySpreadsheetReadOnlyTest, self).setUp()
+
+    def test_too_many_errors(self):
+        # Quick way to make `ErrorHttp` return one more error
+        self.error_http.request_num = -1
+
+        with nose.tools.assert_raises(googleapiclient.errors.HttpError):
+            self.test_refresh()
+
+
+class SpreadsheetReadWriteTest(SpreadsheetTestBase):
 
     def setUp(self):
         self.collection = hyou.collection.Collection(self.api)
@@ -116,3 +151,11 @@ class SpreadsheetReadWriteTest(unittest.TestCase):
         self.assertEqual(2, worksheet.rows)
         self.assertEqual(8, worksheet.cols)
         self.spreadsheet.delete_worksheet('Sheet9')
+
+
+class RetrySpreadsheetReadWriteTest(RetryTestBase, SpreadsheetReadWriteTest):
+    """Same tests as above, but involving retries on server errors."""
+
+    def setUp(self):
+        self.error_http.request_num = 0
+        super(RetrySpreadsheetReadWriteTest, self).setUp()

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -20,10 +20,9 @@ from __future__ import (
 import os
 import unittest
 
-import mock
-
-from hyou import py3
 import hyou.util
+import hyou.py3
+import mock
 
 
 class MiscUtilsTest(unittest.TestCase):
@@ -55,19 +54,19 @@ class ParseCredentialsTest(unittest.TestCase):
     def test_login_user(self):
         json_path = os.path.join(
             os.path.dirname(__file__), 'creds', 'example-user.json')
-        with py3.open(json_path) as f:
+        with hyou.py3.open(json_path) as f:
             hyou.util.parse_credentials(f.read())
 
     def test_login_bot(self):
         json_path = os.path.join(
             os.path.dirname(__file__), 'creds', 'example-bot.json')
-        with py3.open(json_path) as f:
+        with hyou.py3.open(json_path) as f:
             hyou.util.parse_credentials(f.read())
 
     def test_login_invalid(self):
         json_path = os.path.join(
             os.path.dirname(__file__), 'creds', 'example-invalid.json')
-        with py3.open(json_path) as f:
+        with hyou.py3.open(json_path) as f:
             self.assertRaises(
                 ValueError, hyou.util.parse_credentials, f.read())
 
@@ -85,10 +84,10 @@ class LazyOrderedDictionaryTest(unittest.TestCase):
             ('A', 'apple'), ('B', 'banana'), ('C', 'cinamon')]
         # iter()
         it = iter(self.dict)
-        self.assertEqual('A', py3.next(it))
-        self.assertEqual('B', py3.next(it))
-        self.assertEqual('C', py3.next(it))
-        self.assertRaises(StopIteration, py3.next, it)
+        self.assertEqual('A', hyou.py3.next(it))
+        self.assertEqual('B', hyou.py3.next(it))
+        self.assertEqual('C', hyou.py3.next(it))
+        self.assertRaises(StopIteration, hyou.py3.next, it)
         # len()
         self.assertEqual(3, len(self.dict))
         # keys()

--- a/test/view_test.py
+++ b/test/view_test.py
@@ -18,13 +18,12 @@ from __future__ import (
 import unittest
 
 import googleapiclient.errors
-import mock
-import nose.tools
-
 import hyou.api
 import hyou.collection
-from hyou import py3
+import hyou.py3
 import hyou.util
+import mock
+import nose.tools
 
 import http_mocks
 
@@ -35,7 +34,7 @@ CREDENTIALS_FILE = 'unittest-sheets.json'
 class Dummy(object):
 
     def __str__(self):
-        return py3.str_to_native_str('<dummy>', encoding='ascii')
+        return hyou.py3.str_to_native_str('<dummy>', encoding='ascii')
 
 
 class ViewTestBase(unittest.TestCase):

--- a/test/worksheet_test.py
+++ b/test/worksheet_test.py
@@ -17,6 +17,10 @@ from __future__ import (
 
 import unittest
 
+import googleapiclient.errors
+import mock
+import nose.tools
+
 import hyou.api
 import hyou.collection
 import hyou.util
@@ -24,13 +28,35 @@ import hyou.util
 import http_mocks
 
 
-class WorksheetReadOnlyTest(unittest.TestCase):
+CREDENTIALS_FILE = 'unittest-sheets.json'
+
+
+class WorksheetTestBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls.api = hyou.api.API(
-            http_mocks.ReplayHttp('unittest-sheets.json'),
+            http_mocks.ReplayHttp(CREDENTIALS_FILE),
             discovery=False)
+
+
+class RetryTestBase(object):
+
+    sleep_patcher = mock.patch('time.sleep')  # Makes the tests run faster
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sleep_patcher.start()
+        cls.error_http = http_mocks.ErrorHttp(
+            CREDENTIALS_FILE, hyou.api.NUM_RETRIES)
+        cls.api = hyou.api.API(cls.error_http, discovery=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sleep_patcher.stop()
+
+
+class WorksheetReadOnlyTest(WorksheetTestBase):
 
     def setUp(self):
         self.collection = hyou.collection.Collection(self.api)
@@ -59,13 +85,15 @@ class WorksheetReadOnlyTest(unittest.TestCase):
         self.worksheet1.view(start_col=1, end_col=0)
 
 
-class WorksheetReadWriteTest(unittest.TestCase):
+class RetryWorksheetReadOnlyTest(RetryTestBase, WorksheetReadOnlyTest):
+    """Same tests as above, but involving retries on server errors."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.api = hyou.api.API(
-            http_mocks.ReplayHttp('unittest-sheets.json'),
-            discovery=False)
+    def setUp(self):
+        self.error_http.request_num = 0
+        super(RetryWorksheetReadOnlyTest, self).setUp()
+
+
+class WorksheetReadWriteTest(WorksheetTestBase):
 
     def setUp(self):
         self.collection = hyou.collection.Collection(self.api)
@@ -84,3 +112,18 @@ class WorksheetReadWriteTest(unittest.TestCase):
 
     def test_set_cols(self):
         self.worksheet1.cols = 5
+
+
+class RetryWorksheetReadWriteTest(RetryTestBase, WorksheetReadWriteTest):
+    """Same tests as above, but involving retries on server errors."""
+
+    def setUp(self):
+        self.error_http.request_num = 0
+        super(RetryWorksheetReadWriteTest, self).setUp()
+
+    def test_too_many_errors(self):
+        # Quick way to make `ErrorHttp` return one more error
+        self.error_http.request_num = -1
+
+        with nose.tools.assert_raises(googleapiclient.errors.HttpError):
+            self.test_set_size()

--- a/test/worksheet_test.py
+++ b/test/worksheet_test.py
@@ -18,12 +18,11 @@ from __future__ import (
 import unittest
 
 import googleapiclient.errors
-import mock
-import nose.tools
-
 import hyou.api
 import hyou.collection
 import hyou.util
+import mock
+import nose.tools
 
 import http_mocks
 


### PR DESCRIPTION
These errors are usually transient, and retrying might succeed.

We retry 4 times (for a maximum of 5 requests in total), using an exponential backoff strategy. The maximum possible delay is thus 15 seconds.

To deactivate the retry mechanism or change the maximum number of retries, adjust `api.NUM_RETRIES` after the initial import of the library.