### PR TITLE
Ignore worksheets that do not contain cells.

### DIFF
--- a/hyou/spreadsheet.py
+++ b/hyou/spreadsheet.py
@@ -22,6 +22,9 @@ from . import util
 from . import worksheet
 
 
+SHEET_TYPE_GRID = 'GRID'
+
+
 class Spreadsheet(util.LazyOrderedDictionary):
 
     def __init__(self, api, key, entry):
@@ -107,6 +110,9 @@ class Spreadsheet(util.LazyOrderedDictionary):
     def _worksheet_enumerator(self):
         self._ensure_entry()
         for sheet_entry in self._entry['sheets']:
+            if sheet_entry['properties']['sheetType'] != SHEET_TYPE_GRID:
+                # "Object" worksheet, does not have any cells to manipulate
+                continue
             aworksheet = worksheet.Worksheet(self, self._api, sheet_entry)
             yield (aworksheet.title, aworksheet)
 


### PR DESCRIPTION
In Google Spreadsheets, a worksheet can contain just a chart and not have any cells. These worksheets can be ignored as we can't do anything with them.