### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
 
 [testenv:lint]
 commands =
+    pip install -U pip==9.0.3
     flake8 hyou test tools setup.py
 
 [testenv:lint-py2]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27, py33, py34, py35, py36, lint, lint-py2, lint-py3
 
 [testenv]
 deps =
+    pip==9.0.3
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
 commands =


### PR DESCRIPTION
Pin pip to 9.0.3 so that tox tests work.

This avoids having to restructure the Jenkins task.