### PR TITLE
Add public method to access the `spreadsheets.batchUpdate` API endpoint

### DIFF
--- a/hyou/spreadsheet.py
+++ b/hyou/spreadsheet.py
@@ -125,3 +125,13 @@ class Spreadsheet(util.LazyOrderedDictionary):
         response = self._api.sheets.spreadsheets().batchUpdate(
             spreadsheetId=self.key, body=request).execute()
         return response['updatedSpreadsheet']
+
+    @api.retry_on_server_error
+    def make_batch_request(self, requests):
+        request = {
+            'requests': requests,
+            'include_spreadsheet_in_response': True,
+        }
+        response = self._api.sheets.spreadsheets().batchUpdate(
+            spreadsheetId=self.key, body=request).execute()
+        self.refresh(response)


### PR DESCRIPTION
This is useful for a whole lot of additional functionality which doesn't
merit a proper API (yet), such as creating a pivot table, merging cells
or adding custom formatting.

See https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/batchUpdate
for documentation of what requests can be sent.