### PR TITLE
Drop support for old Pythons

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 coverage==4.5.1
-flake8==3.6.0
+flake8==3.9.2
 mock==2.0.0
 nose==1.3.7

--- a/test/view_test.py
+++ b/test/view_test.py
@@ -167,8 +167,8 @@ class ViewReadOnlyTest(ViewTestBase):
     def test_repr(self):
         self.assertEqual(
             str('View(%r)' %
-                [['honoka', 'eri', 'kotori', 'umi', 'rin'],
-                 ['maki', 'nozomi', 'hanayo', 'niko', '']]),
+                ([['honoka', 'eri', 'kotori', 'umi', 'rin'],
+                 ['maki', 'nozomi', 'hanayo', 'niko', '']],)),
             repr(self.view))
 
     def test_properties(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py37, lint, lint-py2, lint-py3
+envlist = py37, py38, py39, lint
 
 [testenv]
 deps =
@@ -11,12 +11,3 @@ commands =
 commands =
     flake8 hyou test tools setup.py
 
-[testenv:lint-py2]
-basepython = python2
-commands =
-    {[testenv:lint]commands}
-
-[testenv:lint-py3]
-basepython = python3
-commands =
-    {[testenv:lint]commands}


### PR DESCRIPTION
Also had to adjust one test, because pyflake thinks that
```python
'%s' % [0, 1]
```
isn't cool.
I actually didn't know that there's a difference to
```python
'%s' % (0, 1)
```
which fails with `TypeError`.